### PR TITLE
Add description of new syntax

### DIFF
--- a/src/content/docs/reference/attributes.md
+++ b/src/content/docs/reference/attributes.md
@@ -5,7 +5,7 @@ title: Attributes
 Attributes are annotations applied to rules that provide additional context or configuration. They are written like this:
 
 ```
-#[atribute_name(parameter_1, parameter_2, ...)]
+#[attribute_name(parameter_1, parameter_2, ...)]
 parent(?p, ?c) :- child(?c, ?p) .
 ```
 

--- a/src/content/docs/reference/attributes.md
+++ b/src/content/docs/reference/attributes.md
@@ -1,0 +1,18 @@
+---
+title: Attributes
+---
+
+Attributes are annotations applied to rules that provide additional context or configuration. They are written like this:
+
+```
+#[atribute_name(parameter_1, parameter_2, ...)]
+parent(?p, ?c) :- child(?c, ?p) .
+```
+
+### Supported attributes
+
+| Attribute    | Parameters      | Explanation |
+| ------------ | --------------- | ------------
+| `name`       | `name(str)`     | Specifies the name of the rule as a constant string. |
+| `display`    | `display(str)`  | Specifies how instantiations of the rule will be displayed. The parameter may use any safe variable from the rule body. |
+

--- a/src/content/docs/reference/builtins.md
+++ b/src/content/docs/reference/builtins.md
@@ -29,6 +29,14 @@ that starts at the given index and extends to the end of the string. Optionally,
 - `CONTAINS`: checks if the string given as the first parameter contains the string given as the second parameter
 - `REGEX`: checks if the string given as the first parameter matches the regular expression given as second the parameter
 
+### Format Strings
+
+Format strings are denoted with a leading `f` before the double quoted string. They allow for arbitrary expressions to be embedded into the string using curly braces `{}`. Format strings are equivalent to using the `CONCAT` builtin function in combination with `STR` for converting the result of the expressions into strings. 
+
+```
+out(f"result: {?x + ?y}") :- in(?x, ?y) .
+```
+
 ### Functions for language tagged strings
 
 A language-tagged string is a value like `"Hello world"@en`. The function `LANG` can be used to extract the language tag (`en` in the example), whereas `STR` can be used to obtain the lexical value (`"Hello world"`).

--- a/src/content/docs/reference/datatypes.md
+++ b/src/content/docs/reference/datatypes.md
@@ -12,7 +12,7 @@ mydata("3.14"^^xsd:double, "2023-06-19"^^xsd:date) .
 ```
 
 However, it is often nicer to use the shortcuts:
-- *Strings* can be written in `"double quotes"` or in `'single quotes'`, and multi-line strings also can be delimited in `"""` and `'''`.
+- *Strings* can be written in `"double quotes 🙂"` and support Unicode.  
 - *Integers* can be written as plain numerals with an optional sign: `42`, `-23`, `+911` all work.
 - *Double precision floats* can be written with decimal point and optional exponent: `3.14`, `.05`, `10.345E6` all work.
 - *Language-tagged strings* are written like in RDF, e.g., `"Dresden"@de` or `ドレスデン@ja`.


### PR DESCRIPTION
Adds description for format strings and attributes. Corrects the statement that single-quoted or multiline strings are supported