### PR TITLE
added documentation for number encodings and bitwise shits

### DIFF
--- a/src/content/docs/reference/builtins.md
+++ b/src/content/docs/reference/builtins.md
@@ -53,6 +53,9 @@ and `INVERTSIGN` (multiply by negative one). Moreover, the following functions r
 - `LOG(x,y)`: computes the logarithm of x to base y
 - `POW(x,y)`: computes the power of x to the y.
 - `REM(x,y)`: computes the remainder of dividing x by y.
+- `BITSHL(x,y)`: computes the bitwise left shift of value x by the base y.
+- `BITSHR(x,y)`: computes the bitwise arithmetic right shift of value x by the base y.
+- `BITSHRU(x,y)`: computes the bitwise logical right shift of value x by the base y.
 
 And finally, the following functions can be called with arbitrary many input parameters:
 - `SUM(x_1, ..., x_n)`: computes the sum of the given arguments
@@ -69,7 +72,7 @@ It is also possible to mix numeric types, which implicitly converts them to 64-b
 ### Conversion functions
 
 Nemo supports the following conversion functions:
-- `INT`: Convert the given value to an integer. This works for various datatypes (not just numbers), but only for data that already corresponds to an integer. The following all evaluate to `42`: `INT(42)`, `INT(42.0)`, `INT("42")`, `INT("42"^^<http://www.w3.org/2001/XMLSchema#gYear>)`, `INT(ROUND(42.1))`. However, `INT(42.1)` does not return a result.
+- `INT`: Convert the given value to an integer. This works for various datatypes (not just numbers), but only for data that already corresponds to an integer. The following all evaluate to `42`: `INT(42)`, `INT(42.0)`, `INT("42")`, `INT("42"^^<http://www.w3.org/2001/XMLSchema#gYear>)`, `INT(ROUND(42.1)), INT("0x2A"), INT("0o52"), INT("0b101010")`. However, `INT(42.1)` does not return a result.
 - `DOUBLE`: Convert a given value to a double. This function works for various datatypes (not just numbers). For example, the following evaluate to `42.0`: `DOUBLE(42)`, `DOUBLE("42.0")`, `DOUBLE("42").`
 - `FLOAT`: Convert a given value to a float. This is analogous to `DOUBLE` but for 32bit floating point numbers.
 - `IRI`: Convert a string value into an IRI

--- a/src/content/docs/reference/datatypes.md
+++ b/src/content/docs/reference/datatypes.md
@@ -16,7 +16,7 @@ However, it is often nicer to use the shortcuts:
 - *Integers* can be written as plain numerals with an optional sign: `42`, `-23`, `+911` all work.
 - Binary, Octal and Hexadecimal numbers starting with the respective prefix `0b`, `0o` or `0x` are interpreted as *unsigned integers*.
 - *Double precision floats* can be written with decimal point and optional exponent: `3.14`, `.05`, `10.345E6` all work.
-- *Language-tagged strings* are written like in RDF, e.g., `"Dresden"@de` or `ドレスデン@ja`.
+- *Language-tagged strings* are written like in RDF, e.g., `"Dresden"@de` or `"ドレスデン"@ja`.
 
 For other datatypes, the long form is needed.
 

--- a/src/content/docs/reference/datatypes.md
+++ b/src/content/docs/reference/datatypes.md
@@ -14,6 +14,7 @@ mydata("3.14"^^xsd:double, "2023-06-19"^^xsd:date) .
 However, it is often nicer to use the shortcuts:
 - *Strings* can be written in `"double quotes 🙂"` and support Unicode. Multi-line strings can also be written using `"""triple quotes"""`.
 - *Integers* can be written as plain numerals with an optional sign: `42`, `-23`, `+911` all work.
+- Binary, Octal and Hexadecimal numbers starting with the respective prefix `0b`, `0o` or `0x` are interpreted as *unsigned integers*.
 - *Double precision floats* can be written with decimal point and optional exponent: `3.14`, `.05`, `10.345E6` all work.
 - *Language-tagged strings* are written like in RDF, e.g., `"Dresden"@de` or `ドレスデン@ja`.
 


### PR DESCRIPTION
This adds documentation for Binary, Octal and Hexadecimal number encodings for the changes by  https://github.com/knowsys/nemo/pull/596.
Additionally documentation for the bitwise shift operations proposed in https://github.com/knowsys/nemo/pull/601 is supplied.